### PR TITLE
WIP Scrambler Agent using python and strongswan in a pod

### DIFF
--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:18.04
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    module-init-tools apt-utils iptables iproute2 bridge-utils jq python-pip \
+    strongswan
+
+RUN mkdir -p /var/lib/scrambler
+WORKDIR /var/lib/scrambler
+
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+
+COPY install.sh agent.sh generate_conf.py generate_cni.py /var/lib/scrambler/

--- a/agent/agent.sh
+++ b/agent/agent.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+cacert="/etc/kubernetes/pki/ca.crt"
+certfile="/var/lib/kubelet/pki/kubelet-client-current.pem"
+ipsec_priv="/etc/ipsec.d/private/kubelet-client.key"
+ipsec_cacert="/etc/ipsec.d/cacerts/kubernetes.crt"
+ipsec_cert="/etc/ipsec.d/certs/kubelet-client.crt"
+
+
+# Check if certs and ipsec.conf need to be updated, if so update and reload them
+update_if_needed() {
+  # If any of the certificates have been updates we need to reload them
+  if [ "$certfile" -nt "$ipsec_cert" ] || [ "$cacert" -nt "$ipsec_cacert" ]; then
+    # Copy the certs into the right place
+    # striping pubkey from the priv and priv from the pub (Strongswan doesn't
+    # like mixed pems).
+    cp "$cacert" "$ipsec_cacert"
+    openssl x509 -in "$certfile" -outform pem -out "$ipsec_cert" > /dev/null
+    openssl ec -in "$certfile" -outform pem -out "$ipsec_priv" > /dev/null
+
+    # Instruct ipsec to reread everything
+    ipsec rereadall || true
+  fi
+
+  # Get the latest config, and diff with the currently used one
+  # if it's changed then write it and reload
+  latest_conf=$(python generate_conf.py $NODENAME)
+  echo "$latest_conf" | diff -s /etc/ipsec.conf - > /dev/null
+  if [ $? -ne 0 ]; then
+    echo "Cluster configuration has changed, updating network config"
+
+    echo "$latest_conf" > /etc/ipsec.conf
+    ipsec update || true
+  fi
+}
+
+
+# load initial config
+update_if_needed
+
+# Tell strongswan to read the private key 
+echo ": ECDSA kubelet-client.key" > /etc/ipsec.secrets
+
+# Start the ipsec daemon
+# Not sure why we have to redirect stdio, but docker wasn't printing stdout
+# until I did this...
+ipsec start --nofork > /dev/stdout 2> /dev/stderr &
+
+# Loop and update the config if needed, i.e. certs get rotated or
+# nodes added/removed
+while :; do
+  update_if_needed
+
+  # TODO, we can improve this using inotifywait and k8s api watcher
+  sleep 10
+done
+
+# Make sure we stop the ipsec bg process
+trap ctrl_c INT TERM;
+ctrl_c() {
+  ipsec stop
+  exit 1
+}

--- a/agent/generate_cni.py
+++ b/agent/generate_cni.py
@@ -1,0 +1,37 @@
+import sys
+from kubernetes import client, config
+
+# Load config from either local or cluster ways
+# keeping this is useful for development, so it can be run directly on a master
+# node
+try:
+  config.load_kube_config()
+except:
+  config.load_incluster_config()
+
+v1 = client.CoreV1Api()
+
+
+
+def generate_cni_conf(nodename):
+  pod_cidr = v1.read_node(nodename).spec.pod_cidr
+  return """{{
+  "cniVersion": "0.2.0",
+  "name": "scrambler",
+  "type": "bridge",
+  "bridge": "scrambler0",
+  "isGateway": true,
+  "ipMasq": true,
+  "ipam": {{
+    "type": "host-local",
+    "subnet": "{pod_cidr}",
+    "routes": [
+      {{ "dst": "0.0.0.0/0" }}
+    ]
+  }}
+}}""".format(pod_cidr=pod_cidr)
+
+
+
+if __name__ == '__main__':
+  print generate_cni_conf(sys.argv[1])

--- a/agent/generate_conf.py
+++ b/agent/generate_conf.py
@@ -1,0 +1,77 @@
+import sys
+from kubernetes import client, config
+
+# Load config from either local or cluster ways
+# keeping this is useful for development, so it can be run directly on a master
+# node
+try:
+  config.load_kube_config()
+except:
+  config.load_incluster_config()
+
+v1 = client.CoreV1Api()
+
+
+
+def config_template(local_node, other_nodes):
+  node_configs = [
+    """
+conn {node[name]}
+    right={node[ip_addresses]}
+    rightsubnet={node[pod_cidr]}
+    rightid="O=system:nodes, CN=system:node:{node[name]}"
+    auto=start
+    """.format(node=node) for node in other_nodes
+  ]
+
+  return """
+config setup
+    charondebug="ike 1, knl 2, cfg 1"
+
+conn %default
+    ikelifetime=60m
+    keylife=20m
+    rekeymargin=3m
+    keyingtries=%forever # keep trying to establish connection
+    keyexchange=ikev2
+    dpdaction=restart # restart if the tunnel dies
+    leftcert=kubelet-client.crt
+    left={local_node[ip_addresses]}
+    leftsubnet={local_node[pod_cidr]}
+    leftfirewall=yes
+    leftsendcert=ifasked
+""".format(local_node=local_node) + "".join(node_configs)
+
+
+def extract_node_info(node):
+  ipv4_addresses = [x.address for x in node.status.addresses if x.type == 'InternalIP']
+  hostnames = [x.address for x in node.status.addresses if x.type == 'Hostname']
+
+  return {
+    'name': node.metadata.name,
+    'hostnames': hostnames,
+    'ip_addresses': ",".join(ipv4_addresses),
+    'pod_cidr': node.spec.pod_cidr
+  }
+
+
+def get_node_by_name(name, nodes):
+  for node in nodes:
+    if node['name'] == name: return node
+  raise Exception("Can't find node %s" % name)
+
+
+def generate_ipsec_conf(local_nodename):
+  # Get all nodes from k8s api
+  ret = v1.list_node()
+
+  # extract the node info we care about and print the generate template
+  all_nodes = [extract_node_info(node) for node in ret.items]
+  local_node = get_node_by_name(local_nodename, all_nodes)
+  other_nodes = [node for node in all_nodes if node != local_node]
+
+  print config_template(local_node, other_nodes)
+
+
+if __name__ == '__main__':
+  generate_ipsec_conf(sys.argv[1])

--- a/agent/install.sh
+++ b/agent/install.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Generate and drop the CNI config in place
+# TODO Don't overwrite an existing config... the rest of the code will read the
+# config
+CNI_FILE="/etc/cni/net.d/10-scrambler.conf"
+python ./generate_cni.py $NODENAME > /etc/cni/net.d/10-scrambler.conf
+
+# Extract the subnet and bridge name from the cni conf
+NODE_CIDR=$(cat $CNI_FILE | jq -r '.ipam.subnet')
+BRIDGE=$(cat $CNI_FILE | jq -r '.bridge')
+
+# Kubernetes will give us the node's cidr (i.e. "10.100.0.0/24"), but we want to
+# assign an ip to the host (i.e. 10.100.0.1), by default `ip addr add` will
+# allow a network address to be assigned to the bridge, so we "massage" it into
+# to a host address (that CNI likes)
+CIDR_HOSTMIN_CIDR=$(echo $NODE_CIDR | sed 's/\([0-9]*\.[0-9]*\.[0-9]*\.\)0/\11/')
+
+# Create the bridge, assign the cidr, and bring it up
+# NOTE: This has to happen *before* strongswan is started
+brctl addbr $BRIDGE
+ip addr add $CIDR_HOSTMIN_CIDR dev $BRIDGE
+ip link set dev $BRIDGE up
+
+# Strongswan creates the xfrm policies that allow routing to anything in the
+# cluster cidr, but we need to route packets originating from the $BRIDGE
+# to the internet ourselves.
+# TODO: See https://wiki.strongswan.org/projects/strongswan/wiki/ForwardingAndSplitTunneling

--- a/agent/requirements.txt
+++ b/agent/requirements.txt
@@ -1,0 +1,1 @@
+kubernetes==7.0.0

--- a/kube-scrambler.yml
+++ b/kube-scrambler.yml
@@ -1,0 +1,109 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: scrambler
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: scrambler
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: scrambler
+subjects:
+- kind: ServiceAccount
+  name: scrambler
+  namespace: kube-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: scrambler
+  namespace: kube-system
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: kube-scrambler-ds
+  namespace: kube-system
+  labels:
+    tier: node
+    app: scrambler
+spec:
+  template:
+    metadata:
+      labels:
+        tier: node
+        app: scrambler
+    spec:
+      hostNetwork: true
+      securityContext:
+        seLinuxOptions:
+          type: spc_t
+      serviceAccountName: scrambler
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      initContainers:
+      - name: install-cni
+        image: quay.io/jameskeane/scrambler
+        securityContext:
+          capabilities:
+            add: ["NET_ADMIN"]
+        env:
+        - name: NODENAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        command:
+        - ./install.sh
+        volumeMounts:
+        - name: cni
+          mountPath: /etc/cni/net.d
+      containers:
+      - name: kube-scrambler-agent
+        image: quay.io/jameskeane/scrambler
+        imagePullPolicy: Always
+        securityContext:
+          capabilities:
+            add: ["NET_ADMIN", "SYS_MODULE"]
+        env:
+        - name: NODENAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        workingDir: /var/lib/scrambler
+        command:
+        - ./agent.sh
+        volumeMounts:
+        - name: host-kube-kpi
+          mountPath: /var/lib/kubelet/pki
+        - name: host-kube-ca
+          mountPath: /etc/kubernetes/pki
+        - name: host-modules
+          mountPath: /lib/modules
+      volumes:
+        - name: cni
+          hostPath:
+            path: /etc/cni/net.d
+        - name: host-modules
+          hostPath:
+            path: /lib/modules
+        - name: host-kube-kpi
+          hostPath:
+            path: /var/lib/kubelet/pki
+        - name: host-kube-ca
+          hostPath:
+            path: /etc/kubernetes/pki


### PR DESCRIPTION
I've got a working demo, that can be installed into a standard kubeadm cluster (`kubectl apply -f kube-scrambler.yaml`).

I haven't integrated it with the vagrant provisioning yet, as it's still a WIP.

**Features**:
 - Uses a pod spec to deploy, same as other networking plugins (calico, flannel, etc)
 - Runs strongswan and scrambler agent in a container, with limited capabilities (not priviledged).
 - Uses configured node x509 certificates and cluster CA to securely authenticate with eachother.
 - Agent container watches for new nodes or changes to the certs and dynamically updates the ipsec config and reloads it.
 - It works.

**Issues**:
 - Haven't verified that all packets that *should* be tunneled *are* tunneled.
 - Using python is kind of a drag, it requires ~300mb to the agent's docker image.
 - Although pods can talk to eachother, they currently can't talk to the internet (I still need to figure out how to set up the netfilter rules _while_ respecting the ipsec policy)